### PR TITLE
feat: :sparkles: support environment variables for configuration

### DIFF
--- a/Fathom.astro
+++ b/Fathom.astro
@@ -14,8 +14,8 @@ export type Props = {
 
 const {
 	enabled = import.meta.env.PROD,
-	trackingUrl = "https://cdn.usefathom.com",
-	site,
+	trackingUrl = import.meta.env.FATHOM_TRACKING_URL || "https://cdn.usefathom.com",
+	site = import.meta.env.FATHOM_SITE,
 	honorDnt = false,
 	auto = true,
 	canonical = true,
@@ -25,6 +25,15 @@ const {
 	spa = "auto",
 } = Astro.props
 
+if (!trackingUrl) {
+	throw new Error(`[astro-fathom] "trackingUrl" or the "FATHOM_TRACKING_URL" environment variable are required`)
+}
+
+if (!site) {
+	throw new Error(`[astro-fathom] "site or the "FATHOM_SITE" environment variable is required`)
+}
+
+// TODO: a future release of Fathom Analytics will support loading the tracking script from the domain root
 const src = new URL("script.js", trackingUrl).toString()
 
 const loadProps = {

--- a/README.md
+++ b/README.md
@@ -43,22 +43,26 @@ Just looking for a basic script installation? That's it, you're all set!
 
 The Fathom script will be included in all production builds. When running with `astro dev`, `window.fathom` will be shimmed with a logger that outputs all tracking events to the browser's console instead.
 
+### Environment variables
+
+It's common to setup keep analytics events separate for different deployment environments - for example `test`, `staging`, and `production`. We recommend using the environment variables listed below to configure the correct `site` and `trackingUrl`, keeping your analytics configuration in the same place as your other environment configuration variables.
+
 ### Available options
 
 See the Fathom docs for more information on these [advanced tracking options](https://usefathom.com/support/tracking-advanced).
 
-| Name              | Type                                        | Default                     | Description                                        |
-| ----------------- | ------------------------------------------- | --------------------------- | -------------------------------------------------- |
-| `enabled`         | Boolean                                     | `import.meta.env.PROD`      | When disabled, events are logged to the console    |
-| `site`            | String                                      | no default                  | Your Fathom site id (required)                     |
-| `trackingUrl`     | String                                      | `https://cdn.usefathom.com` | Your Fathom custom domain                          |
-| `honorDnt`        | Boolean                                     | `false`                     | Honor Do Not Track?                                |
-| `auto`            | Boolean                                     | `true`                      | Automatically track page views?                    |
-| `canonical`       | Boolean                                     | `true`                      | Use the canonical URL, instead of the current URL? |
-| `excludedDomains` | String[]                                    | []                          | Excludes tracking for these domains                |
-| `includedDomains` | String[]                                    | []                          | Include tracking for these domains                 |
-| `spa`             | `"auto"`, `"history"` or `"hash"`           | `"auto"`                    | Tracking mode                                      |
-| `loadType`        | `"defer"` or `"async"`                      | `"defer"`                   | Tracking mode                                      |
+| Name              | Type                                        | Default                                                              | Description                                        |
+| ----------------- | ------------------------------------------- | ---------------------------                                          | -------------------------------------------------- |
+| `enabled`         | Boolean                                     | `import.meta.env.PROD`                                               | When disabled, events are logged to the console    |
+| `site`            | String                                      | `import.meta.env.FATHOM_SITE`                                        | Your Fathom site id (required)                     |
+| `trackingUrl`     | String                                      | `import.meta.env.FATHOM_TRACKING_URL` or `https://cdn.usefathom.com` | Your Fathom custom domain                          |
+| `honorDnt`        | Boolean                                     | `false`                                                              | Honor Do Not Track?                                |
+| `auto`            | Boolean                                     | `true`                                                               | Automatically track page views?                    |
+| `canonical`       | Boolean                                     | `true`                                                               | Use the canonical URL, instead of the current URL? |
+| `excludedDomains` | String[]                                    | []                                                                   | Excludes tracking for these domains                |
+| `includedDomains` | String[]                                    | []                                                                   | Include tracking for these domains                 |
+| `spa`             | `"auto"`, `"history"` or `"hash"`           | `"auto"`                                                             | Tracking mode                                      |
+| `loadType`        | `"defer"` or `"async"`                      | `"defer"`                                                            | Tracking mode                                      |
 
 #### Example
 
@@ -69,8 +73,11 @@ import { Fathom } from "astro-fathom"
 
 <html>
     <head>
-        <!-- head stuff -->
-        <Fathom site="ABCDEFGH" trackingUrl="https://actor-endorsed.example.com" honorDnt />
+        <!-- with FATHOM environment variables -->
+        <Fathom />
+
+        <!-- or if you prefer to inline configuration variables -->
+        <Fathom site="ABCDEFGH" trackingUrl="https://actor-endorsed.example.com" />
     </head>
 </html>
 ```

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ The Fathom script will be included in all production builds. When running with `
 
 ### Environment variables
 
-It's common to setup keep analytics events separate for different deployment environments - for example `test`, `staging`, and `production`. We recommend using the environment variables listed below to configure the correct `site` and `trackingUrl`, keeping your analytics configuration in the same place as your other environment configuration variables.
+It's common to keep analytics events separate for different deployment environments - for example `test`, `staging`, and `production`. We recommend using the environment variables listed below to configure the correct `site` and `trackingUrl`, keeping your analytics configuration in the same place as your other environment configuration variables.
 
 ### Available options
 


### PR DESCRIPTION
This adds support for using `FATHOM_SITE` and `FATHOM_TRACKING_URL` environment variables to configure the Fathom script instead of inline component props

**Why?**

To better support a common use case where different environments (`test`, `staging`, `prod`, etc) use different Fathom sites to isolate analytics data.